### PR TITLE
Improve GEO readiness and homepage copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ AGENTS.md
 /.next/
 /out/
 
+# astro
+/.astro/
+/dist/
+
 # production
 /build
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,25 @@
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import vercel from "@astrojs/vercel";
+import geoReady from "astro-geoready";
 
 const fromRoot = (value) => fileURLToPath(new URL(value, import.meta.url));
+const siteConfig = JSON.parse(
+  readFileSync(new URL("./site.config.json", import.meta.url), "utf8"),
+);
 
 export default defineConfig({
   site: "https://www.senna-automation.com",
   output: "static",
-  integrations: [react()],
+  integrations: [
+    react(),
+    geoReady({
+      siteName: siteConfig.siteName,
+      description: siteConfig.siteDescription,
+    }),
+  ],
   adapter: vercel(),
   image: {
     remotePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/pg": "^8.20.0",
         "@vercel/og": "^0.11.1",
         "astro": "^7.0.6",
+        "astro-geoready": "file:./vendor/astro-geoready",
         "axios": "^1.18.1",
         "better-auth": "^1.6.20",
         "feed": "^5.2.1",
@@ -4348,6 +4349,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/astro-geoready": {
+      "resolved": "vendor/astro-geoready",
+      "link": true
     },
     "node_modules/astro/node_modules/fsevents": {
       "version": "2.3.3",
@@ -10629,6 +10634,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "vendor/astro-geoready": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "astro": ">=4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/pg": "^8.20.0",
     "@vercel/og": "^0.11.1",
     "astro": "^7.0.6",
+    "astro-geoready": "file:./vendor/astro-geoready",
     "axios": "^1.18.1",
     "better-auth": "^1.6.20",
     "feed": "^5.2.1",

--- a/public/home-work.vtt
+++ b/public/home-work.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:03.500
+Homepage demo video showing a Senna Automation workflow interface.
+
+00:00:03.500 --> 00:00:07.000
+Automation steps move between tasks, messages, and operating dashboards.
+
+00:00:07.000 --> 00:00:10.500
+The video illustrates how routine work can be routed and completed automatically.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,13 +4,22 @@
 
 Senna Automation helps small and mid-sized businesses reduce repetitive work, improve operational handoffs, and build custom AI-enabled systems around the tools they already use.
 
+For the complete public page inventory, see [llms-full.txt](https://www.senna-automation.com/llms-full.txt).
+
 ## Core Pages
 
 - [Home](https://www.senna-automation.com/): Overview of Senna Automation and its AI workflow automation work.
+- [About](https://www.senna-automation.com/about): Company background, founder, and operating approach.
 - [Services](https://www.senna-automation.com/services): Service areas including workflow automation, lead generation, sales automation, assistants, and internal tools.
 - [Solutions](https://www.senna-automation.com/solutions): Common business bottlenecks and automation patterns.
 - [Pricing](https://www.senna-automation.com/pricing): Pricing model and implementation expectations.
 - [Contact](https://www.senna-automation.com/contact): Contact and automation audit form.
+
+## Local Search Pages
+
+- [AI Consulting in Grand Rapids](https://www.senna-automation.com/ai-consulting-grand-rapids): Local service page for practical AI consulting and workflow planning.
+- [AI Automation in Grand Rapids](https://www.senna-automation.com/ai-automation-grand-rapids): Local service page for business automation and operations workflows.
+- [Workflow Automation Consultant in Grand Rapids](https://www.senna-automation.com/workflow-automation-consultant-grand-rapids): Local service page focused on process automation consulting.
 
 ## Case Studies And Insights
 
@@ -25,3 +34,11 @@ Senna Automation helps small and mid-sized businesses reduce repetitive work, im
 - [RSS feed](https://www.senna-automation.com/rss.xml): RSS 2.0 blog feed.
 - [Atom feed](https://www.senna-automation.com/atom.xml): Atom blog feed.
 - [JSON feed](https://www.senna-automation.com/feed.json): JSON Feed for blog posts.
+
+## Optional
+
+- [Search](https://www.senna-automation.com/search): Public site search for pages, location content, and blog posts.
+- [Full public page index](https://www.senna-automation.com/llms-full.txt): Broader inventory of published pages, blog posts, feeds, and legal pages.
+- [Sitemap](https://www.senna-automation.com/sitemap.xml): Canonical XML sitemap of public URLs.
+- [Privacy Policy](https://www.senna-automation.com/privacy): Privacy and data handling details.
+- [Terms](https://www.senna-automation.com/terms): Website terms and usage conditions.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,33 @@
 User-agent: *
 Allow: /
 
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 Sitemap: https://www.senna-automation.com/sitemap.xml
 Sitemap: https://www.senna-automation.com/rss.xml
 Sitemap: https://www.senna-automation.com/atom.xml

--- a/site.config.json
+++ b/site.config.json
@@ -1,6 +1,7 @@
 {
   "siteName": "Senna Automation",
   "siteUrl": "https://www.senna-automation.com",
+  "siteDescription": "Senna Automation helps small and mid-sized businesses reduce repetitive work, improve operational handoffs, and build custom AI-enabled systems around the tools they already use.",
   "indexNowKey": "ade46be238dcf9db16441ff765b12bd4",
   "webSubHubUrl": "https://pubsubhubbub.appspot.com/"
 }

--- a/src/components/AnimatedHeroTitle.tsx
+++ b/src/components/AnimatedHeroTitle.tsx
@@ -41,7 +41,7 @@ export default function AnimatedHeroTitle() {
             textTransform: "uppercase",
           }}
         >
-          Let the
+          Let the{" "}
         </Box>
         <Box
           component="span"
@@ -72,7 +72,7 @@ export default function AnimatedHeroTitle() {
           >
             B
           </Box>
-          usywork
+          usywork{" "}
         </Box>
         <Box
           component="span"

--- a/src/components/RequestFormButton.tsx
+++ b/src/components/RequestFormButton.tsx
@@ -12,6 +12,7 @@ interface RequestFormButtonProps {
   fullWidth?: boolean;
   href?: string;
   sx?: any;
+  ariaLabel?: string;
 }
 
 export default function RequestFormButton({
@@ -21,7 +22,14 @@ export default function RequestFormButton({
   fullWidth = false,
   href = "/contact",
   sx = {},
+  ariaLabel,
 }: RequestFormButtonProps) {
+  const requestActionAttributes = {
+    toolname: "request_assessment",
+    tooldescription:
+      "Open the relevant page to request a workflow assessment or next-step conversation.",
+  } as const;
+
   return (
     <Button 
       component={Link} 
@@ -30,6 +38,8 @@ export default function RequestFormButton({
       size={size} 
       fullWidth={fullWidth}
       onClick={() => trackCta(text)}
+      aria-label={ariaLabel ?? text}
+      {...requestActionAttributes}
       sx={{
         borderRadius: "var(--radius-pill)",
         fontWeight: "bold",

--- a/src/components/ScheduleCallButton.tsx
+++ b/src/components/ScheduleCallButton.tsx
@@ -30,6 +30,7 @@ interface ScheduleCallButtonProps {
   sx?: any;
   showIcon?: boolean;
   inverse?: boolean;
+  ariaLabel?: string;
 }
 
 export default function ScheduleCallButton({
@@ -40,6 +41,7 @@ export default function ScheduleCallButton({
   sx = {},
   showIcon = true,
   inverse = false,
+  ariaLabel,
 }: ScheduleCallButtonProps) {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -65,6 +67,12 @@ export default function ScheduleCallButton({
     // Redirect to confirmation after closing
   };
 
+  const schedulingActionAttributes = {
+    toolname: "schedule_call",
+    tooldescription:
+      "Open the scheduling modal to book a workflow consultation with Senna Automation.",
+  } as const;
+
   return (
     <>
       <Button
@@ -72,6 +80,8 @@ export default function ScheduleCallButton({
         size={size}
         onClick={handleOpen}
         fullWidth={fullWidth}
+        aria-label={ariaLabel ?? text}
+        {...schedulingActionAttributes}
         sx={{
           borderRadius: "var(--radius-pill)",
           fontWeight: "bold",
@@ -201,7 +211,7 @@ export default function ScheduleCallButton({
                     bgcolor: alpha(ACCENT, 0.1),
                   },
                 }}
-                aria-label="close"
+                aria-label="Close scheduling modal"
               >
                 <CloseIcon />
               </IconButton>

--- a/src/components/animations/CascadingStagger.tsx
+++ b/src/components/animations/CascadingStagger.tsx
@@ -14,7 +14,7 @@ interface CascadingStaggerProps extends StackProps {
  */
 export default function CascadingStagger({ children, spacing = 2, ...props }: CascadingStaggerProps) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
     const node = ref.current;
@@ -22,9 +22,10 @@ export default function CascadingStagger({ children, spacing = 2, ...props }: Ca
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (!entry.isIntersecting) return;
-        setIsVisible(true);
-        observer.disconnect();
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
       },
       { threshold: 0.1 },
     );

--- a/src/components/animations/Reveal.tsx
+++ b/src/components/animations/Reveal.tsx
@@ -56,16 +56,10 @@ export default function Reveal({
   once = true,
 }: RevealProps) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
-    if (trigger === "mount") {
-      const frame = window.requestAnimationFrame(() => {
-        setIsVisible(true);
-      });
-
-      return () => window.cancelAnimationFrame(frame);
-    }
+    if (trigger === "mount") return;
 
     const node = ref.current;
     if (!node) return;

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -8,6 +8,8 @@ import {
   RadioGroup,
   FormControlLabel,
   Radio,
+  FormControl,
+  FormLabel,
   Typography,
   Container,
   Grid,
@@ -147,7 +149,7 @@ export default function ContactForm() {
                   textAlign: { xs: "center", md: "left" }
                 }}>
                 No prep needed. We&apos;ll walk through your current process and
-                find where automation can help.
+                find where a better system can help.
               </Typography>
                 <Typography
                   variant="body1"
@@ -181,6 +183,7 @@ export default function ContactForm() {
                 component="form"
                 id="contact-form"
                 onSubmit={handleSubmit}
+                aria-label="Request a workflow assessment"
                 sx={{
                   width: "100%",
                   "& .MuiInputLabel-root.MuiInputLabel-shrink": {
@@ -194,6 +197,8 @@ export default function ContactForm() {
                   id="contact-name"
                   label="Your Name"
                   placeholder="John Smith"
+                  name="name"
+                  autoComplete="name"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   margin="normal"
@@ -230,8 +235,11 @@ export default function ContactForm() {
                   placeholder="Acme Corp"
                   value={company}
                   onChange={(e) => setCompany(e.target.value)}
+                  name="company"
+                  autoComplete="organization"
                   margin="normal"
                   aria-label="Enter your company name"
+                  helperText="Optional, but useful if you want us to tailor the conversation to your team."
                   sx={{
                     "& .MuiOutlinedInput-root": {
                       bgcolor: "var(--color-bg-paper)",
@@ -263,10 +271,12 @@ export default function ContactForm() {
                   id="contact-assistance"
                   label="How can we assist you?"
                   placeholder="What’s taking too much time right now?"
+                  name="assistance"
                   value={assistance}
                   onChange={(e) => setAssistance(e.target.value)}
                   margin="normal"
                   aria-label="Describe how we can help your business"
+                  helperText="Describe the bottleneck, handoff, or repetitive work you want to improve."
                   multiline
                   rows={3}
                   sx={{
@@ -294,17 +304,29 @@ export default function ContactForm() {
                     },
                   }}
                 />
-                <Typography
+                <FormControl component="fieldset" sx={{ mt: 2, mb: 1 }}>
+                  <FormLabel
+                    component="legend"
+                    sx={{
+                      color: "text.primary",
+                      "&.Mui-focused": {
+                        color: "var(--color-accent)",
+                      },
+                    }}
+                  >
+                    Preferred Contact Method *
+                  </FormLabel>
+                  <Typography
                   variant="body2"
                   sx={{
                     color: "text.primary",
-                    mt: 2,
                     mb: 1
                   }}>
-                  Preferred Contact Method *
-                </Typography>
-                <RadioGroup
+                    Choose the channel you want us to use for follow-up.
+                  </Typography>
+                  <RadioGroup
                   row
+                  name="contactMethod"
                   aria-label="Select your preferred contact method"
                   value={contactMethod}
                   onChange={(e) => setContactMethod(e.target.value)}
@@ -337,19 +359,19 @@ export default function ContactForm() {
                     value="email"
                     control={<Radio />}
                     label="Email"
-                    id="contact-email"
                   />
                   <FormControlLabel
                     value="sms"
                     control={<Radio />}
                     label="SMS / Phone"
-                    id="contact-sms"
                   />
-                </RadioGroup>
+                  </RadioGroup>
+                </FormControl>
                 <TextField
                   fullWidth
                   required
                   id="contact-value"
+                  name="contactValue"
                   label={
                     contactMethod === "email"
                       ? "Your Email Address"
@@ -361,6 +383,7 @@ export default function ContactForm() {
                       ? "john@company.com"
                       : "(616) 555-1234"
                   }
+                  autoComplete={contactMethod === "email" ? "email" : "tel"}
                   value={contactValue}
                   onChange={(e) => setContactValue(e.target.value)}
                   onBlur={() => setTouched(true)}
@@ -376,7 +399,9 @@ export default function ContactForm() {
                       ? contactMethod === "email"
                         ? "Please enter a valid email address (e.g., name@domain.com)"
                         : "Please enter a valid phone number (e.g., (616) 555-1234)"
-                      : ""
+                      : contactMethod === "email"
+                        ? "We will use this address for the initial reply."
+                        : "We will use this number for a call or text reply."
                   }
                   sx={{
                     "& .MuiOutlinedInput-root": {
@@ -421,6 +446,8 @@ export default function ContactForm() {
                   }}
                   disabled={!isValidContact}
                   aria-label="Submit your contact request"
+                  toolname="submit_contact_request"
+                  tooldescription="Submit the contact form to request a workflow assessment from Senna Automation."
                 >
                   Request My Free Audit
                 </Button>

--- a/src/components/home/SennaAdvantageVideo.tsx
+++ b/src/components/home/SennaAdvantageVideo.tsx
@@ -69,6 +69,13 @@ export default function SennaAdvantageVideo() {
         }}
       >
         <source src="/home-work.mp4" type="video/mp4" />
+        <track
+          kind="captions"
+          src="/home-work.vtt"
+          srcLang="en"
+          label="English captions"
+          default
+        />
       </Box>
 
       <Box

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -28,7 +28,7 @@ const localFooterLinks = [
     heading: "Local",
     links: [
       { label: "AI Consulting", href: "/ai-consulting-grand-rapids" },
-      { label: "AI Automation", href: "/ai-automation-grand-rapids" },
+      { label: "AI Systems", href: "/ai-automation-grand-rapids" },
       {
         label: "Workflow Consultant",
         href: "/workflow-automation-consultant-grand-rapids",
@@ -38,6 +38,7 @@ const localFooterLinks = [
   {
     heading: "Explore",
     links: [
+      { label: "Search", href: "/search" },
       { label: "Contact", href: "/contact" },
       { label: "Privacy", href: "/privacy" },
       { label: "Terms", href: "/terms" },

--- a/src/pages/ai/faq.json.ts
+++ b/src/pages/ai/faq.json.ts
@@ -1,0 +1,19 @@
+import type { APIRoute } from "astro";
+import { formatAiFaqAnswer, homeFaqEntries } from "@/utils/ai-discovery";
+
+export const prerender = true;
+
+export const GET: APIRoute = () => {
+  const body = {
+    faqs: homeFaqEntries.map((entry) => ({
+      question: entry.question,
+      answer: formatAiFaqAnswer(entry),
+    })),
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/ai/service.json.ts
+++ b/src/pages/ai/service.json.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { aiServiceProfile } from "@/utils/ai-discovery";
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(JSON.stringify(aiServiceProfile, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,147 @@
+import type { APIRoute } from "astro";
+import { localSeoPages } from "@/components/localSeo/localSeoPages";
+import { getAllBlogPostsFromContent } from "@/utils/astro-blog";
+import {
+  ATOM_FEED_URL,
+  JSON_FEED_URL,
+  RSS_FEED_URL,
+  SITE_NAME,
+  SITE_URL,
+} from "@/utils/site";
+
+export const prerender = true;
+
+type LinkEntry = {
+  title: string;
+  url: string;
+  description?: string;
+};
+
+function renderSection(title: string, entries: LinkEntry[]) {
+  return [
+    `## ${title}`,
+    "",
+    ...entries.map((entry) =>
+      entry.description
+        ? `- [${entry.title}](${entry.url}): ${entry.description}`
+        : `- [${entry.title}](${entry.url})`,
+    ),
+    "",
+  ].join("\n");
+}
+
+export const GET: APIRoute = async () => {
+  const blogPosts = await getAllBlogPostsFromContent();
+
+  const sections = [
+    renderSection("Core Pages", [
+      {
+        title: "Home",
+        url: SITE_URL,
+        description:
+          "Overview of Senna Automation and its AI workflow automation consulting.",
+      },
+      {
+        title: "About",
+        url: `${SITE_URL}/about`,
+        description: "Company background, founder, and operating approach.",
+      },
+      {
+        title: "Services",
+        url: `${SITE_URL}/services`,
+        description: "Service areas and common automation outcomes.",
+      },
+      {
+        title: "Solutions",
+        url: `${SITE_URL}/solutions`,
+        description: "Common business bottlenecks and automation patterns.",
+      },
+      {
+        title: "Pricing",
+        url: `${SITE_URL}/pricing`,
+        description: "Engagement model and starting price points.",
+      },
+      {
+        title: "Contact",
+        url: `${SITE_URL}/contact`,
+        description: "Contact page and automation assessment request.",
+      },
+      {
+        title: "Search",
+        url: `${SITE_URL}/search`,
+        description: "Public search across pages, location content, and blog posts.",
+      },
+      {
+        title: "Blog",
+        url: `${SITE_URL}/blog`,
+        description: "Automation case studies and practical implementation articles.",
+      },
+    ]),
+    renderSection(
+      "Local Search Pages",
+      Object.values(localSeoPages).map((page) => ({
+        title: page.serviceName,
+        url: `${SITE_URL}/${page.slug}`,
+        description: page.description,
+      })),
+    ),
+    renderSection(
+      "Blog Posts",
+      blogPosts.map((post) => ({
+        title: post.title,
+        url: `${SITE_URL}/blog/${post.slug}`,
+        description: post.excerpt,
+      })),
+    ),
+    renderSection("Feeds", [
+      {
+        title: "RSS feed",
+        url: RSS_FEED_URL,
+        description: "RSS 2.0 feed for blog content.",
+      },
+      {
+        title: "Atom feed",
+        url: ATOM_FEED_URL,
+        description: "Atom feed for blog content.",
+      },
+      {
+        title: "JSON Feed",
+        url: JSON_FEED_URL,
+        description: "Machine-readable JSON feed for blog content.",
+      },
+    ]),
+    renderSection("Optional", [
+      {
+        title: "Sitemap",
+        url: `${SITE_URL}/sitemap.xml`,
+        description: "Canonical XML sitemap for all public pages.",
+      },
+      {
+        title: "Privacy Policy",
+        url: `${SITE_URL}/privacy`,
+        description: "Privacy and data handling details.",
+      },
+      {
+        title: "Terms",
+        url: `${SITE_URL}/terms`,
+        description: "Website terms and usage conditions.",
+      },
+    ]),
+  ];
+
+  const body = [
+    `# ${SITE_NAME} Full Index`,
+    "",
+    "> Complete public page inventory for AI systems, including marketing pages, location pages, published blog posts, and feeds.",
+    "",
+    `Use [${SITE_URL}/llms.txt](${SITE_URL}/llms.txt) for the curated orientation file and this document for the broader public index.`,
+    "",
+    ...sections,
+  ].join("\n");
+
+  return new Response(`${body}\n`, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,17 @@
+---
+import RouteShell from "@/components/app/RouteShell.astro";
+import MuiProviders from "@/components/app/MuiProviders";
+import SearchPage, { metadata } from "@/site/pages/search";
+import { searchSiteContent } from "@/utils/search";
+
+export const prerender = false;
+
+const query = Astro.url.searchParams.get("q")?.trim() ?? "";
+const results = searchSiteContent(query);
+---
+
+<RouteShell metadata={metadata} pathname="/search">
+  <MuiProviders>
+    <SearchPage query={query} results={results} />
+  </MuiProviders>
+</RouteShell>

--- a/src/site/feeds/sitemap.ts
+++ b/src/site/feeds/sitemap.ts
@@ -55,6 +55,11 @@ export default function sitemap(): SitemapEntry[] {
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/search`,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
       url: `${SITE_URL}/blog`,
       ...(latestPostLastModified
         ? { lastModified: latestPostLastModified }

--- a/src/site/pages/home.tsx
+++ b/src/site/pages/home.tsx
@@ -233,16 +233,6 @@ export default function Home({
                 maxWidth: { xs: "100%", md: 760 },
                 textAlign: { xs: "center", md: "left" }
               }}>
-              <Typography
-                variant="overline"
-                sx={{
-                  ...homeEyebrowSx,
-                  mb: 2,
-                  alignSelf: { xs: "center", md: "flex-start" },
-                }}
-              >
-                Workflow systems for lead follow-up, quoting, scheduling, and internal handoffs
-              </Typography>
               <AnimatedHeroTitle />
               <Box
                 component="hr"

--- a/src/site/pages/home.tsx
+++ b/src/site/pages/home.tsx
@@ -1,15 +1,17 @@
-import type { ReactNode } from "react";
 import Image, { type StaticImageData } from "@/compat/next/image";
+import Script from "@/compat/next/script";
 import type { RouteMetadata } from "@/utils/metadata";
 import RequestFormButton from "@/components/RequestFormButton";
 import SennaAdvantageVideo from "@/components/home/SennaAdvantageVideo";
 import type { BlogPostPreview } from "@/types/blog";
+import { homeFaqEntries, formatAiFaqAnswer } from "@/utils/ai-discovery";
+import { SITE_NAME, SITE_URL } from "@/utils/site";
 
 export const metadata: RouteMetadata = {
   title:
-    "AI Workflow Automation & Business Process Automation | Senna Automation",
+    "AI Workflow Systems & Business Process Design | Senna Automation",
   description:
-    "Senna Automation helps businesses in Grand Rapids, MI and beyond eliminate repetitive work with AI-powered workflow automation. Schedule a free 30-min call to see what you can automate.",
+    "AI-powered workflow systems for Grand Rapids businesses that need faster lead follow-up, cleaner handoffs, and less repetitive back-office work.",
   alternates: {
     canonical: "https://www.senna-automation.com",
   },
@@ -18,9 +20,6 @@ export const metadata: RouteMetadata = {
 import AnimatedHeroTitle from "@/components/AnimatedHeroTitle";
 import ScheduleCallButton from "@/components/ScheduleCallButton";
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Box,
   Card,
   CardContent,
@@ -29,88 +28,11 @@ import {
   Typography,
   Grid,
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CascadingStagger from "@/components/animations/CascadingStagger";
 import Link from "@/compat/next/link";
 import { Button } from "@mui/material";
 import FinalCTA from "@/components/sections/FinalCTA";
 import LocalSeoClusterSection from "@/components/localSeo/LocalSeoClusterSection";
-
-const faqs: Array<{ question: string; answer: ReactNode }> = [
-  {
-    question: "How is this different from other automation tools?",
-    answer: (
-      <>
-        <Box component="p" sx={{ m: 0 }}>
-          There are already powerful automation platforms out there, but most
-          are built for large teams and require time to learn and maintain.
-        </Box>
-        <Box component="p" sx={{ mt: 2, mb: 0 }}>
-          This is different. You&apos;re getting a system designed around your
-          business that actually runs, not a tool you have to manage.
-        </Box>
-      </>
-    ),
-  },
-  {
-    question: "Do I need to be technical to use this?",
-    answer: (
-      <>
-        <Box component="p" sx={{ m: 0 }}>
-          No.
-        </Box>
-        <Box component="p" sx={{ mt: 2, mb: 0 }}>
-          Everything is set up to match how your business already works. You and
-          your team just interact with simple inputs like emails, forms, or
-          messages, and the system handles the rest quietly in the background.
-        </Box>
-      </>
-    ),
-  },
-  {
-    question: "What kinds of things can actually be automated?",
-    answer: (
-      <>
-        <Box component="p" sx={{ m: 0 }}>
-          Anything that follows a pattern.
-        </Box>
-        <Box component="p" sx={{ mt: 2, mb: 0 }}>
-          That usually includes:
-        </Box>
-        <Box component="ul" sx={{ mt: 1.5, mb: 0, pl: 3 }}>
-          <Box component="li">
-            Incoming leads getting organized and qualified
-          </Box>
-          <Box component="li">Follow-ups happening without reminders</Box>
-          <Box component="li">Scheduling handled without back-and-forth</Box>
-          <Box component="li">
-            Invoices or documents created from conversations
-          </Box>
-          <Box component="li">
-            Tasks moving between people without manual coordination
-          </Box>
-        </Box>
-        <Box component="p" sx={{ mt: 2, mb: 0 }}>
-          Most businesses are already doing this work manually.
-        </Box>
-      </>
-    ),
-  },
-  {
-    question: "How do I get started?",
-    answer: (
-      <>
-        <Box component="p" sx={{ m: 0 }}>
-          We start by looking at where work is getting stuck or repeated.
-        </Box>
-        <Box component="p" sx={{ mt: 2, mb: 0 }}>
-          From there, we build one system that takes that off your plate. Once
-          that&apos;s running, we expand into other areas.
-        </Box>
-      </>
-    ),
-  },
-];
 
 import hubspot from "@/assets/home/integrations/hubspot.png";
 import quickbooks from "@/assets/home/integrations/quickbooks.png";
@@ -199,6 +121,60 @@ const homeEyebrowSx = {
   letterSpacing: "0.12em",
 };
 
+const homePageVideoTranscript =
+  "Homepage demo video showing a workflow interface. Steps move between tasks, messages, and operating dashboards. The video illustrates how routine work can be routed and completed in the background.";
+
+const homePageStructuredData = {
+  webpage: {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${SITE_URL}/#webpage`,
+    url: SITE_URL,
+    name: String(metadata.title),
+    description: metadata.description,
+    inLanguage: "en-US",
+    isPartOf: {
+      "@id": `${SITE_URL}/#website`,
+    },
+    about: {
+      "@id": `${SITE_URL}/#organization`,
+    },
+    dateModified: "2026-04-08T13:35:58Z",
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}/og/default.png`,
+    },
+  },
+  faq: {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: homeFaqEntries.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: formatAiFaqAnswer(entry),
+      },
+    })),
+  },
+  video: {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    name: "Workflow systems overview video",
+    description:
+      "Short homepage overview showing how workflow systems can move routine tasks through client operations.",
+    thumbnailUrl: [`${SITE_URL}/og/default.png`],
+    uploadDate: "2026-04-08T13:35:58Z",
+    contentUrl: `${SITE_URL}/home-work.mp4`,
+    embedUrl: SITE_URL,
+    inLanguage: "en-US",
+    transcript: homePageVideoTranscript,
+    publisher: {
+      "@id": `${SITE_URL}/#organization`,
+    },
+  },
+};
+
 type HomeFeaturedPost = Pick<
   BlogPostPreview,
   "slug" | "title" | "excerpt" | "image"
@@ -211,6 +187,27 @@ export default function Home({
 }) {
   return (
     <>
+      <Script
+        id="home-webpage-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(homePageStructuredData.webpage),
+        }}
+      />
+      <Script
+        id="home-faq-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(homePageStructuredData.faq),
+        }}
+      />
+      <Script
+        id="home-video-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(homePageStructuredData.video),
+        }}
+      />
       {/* ── Hero ─────────────────────────────────────── */}
       <Box
         component="section"
@@ -236,6 +233,16 @@ export default function Home({
                 maxWidth: { xs: "100%", md: 760 },
                 textAlign: { xs: "center", md: "left" }
               }}>
+              <Typography
+                variant="overline"
+                sx={{
+                  ...homeEyebrowSx,
+                  mb: 2,
+                  alignSelf: { xs: "center", md: "flex-start" },
+                }}
+              >
+                Workflow systems for lead follow-up, quoting, scheduling, and internal handoffs
+              </Typography>
               <AnimatedHeroTitle />
               <Box
                 component="hr"
@@ -256,12 +263,38 @@ export default function Home({
                 sx={{
                   color: "text.secondary",
                   mt: 0,
-                  mb: 4,
+                  mb: 2,
                   maxWidth: 720,
                   textAlign: { xs: "center", md: "left" }
                 }}>
-                Support your team with systems that handle the repetitive work.
-                So they can focus on the work that moves things forward.
+                For small and mid-sized teams, we turn lead follow-up, quoting,
+                routing, scheduling, and repetitive back-office work into
+                practical AI-powered systems.
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{
+                  color: "text.secondary",
+                  mb: 4,
+                  maxWidth: 720,
+                  textAlign: { xs: "center", md: "left" },
+                }}
+              >
+                We build practical systems around the tools you already use, so
+                handoffs keep moving and your team spends less time chasing
+                status updates.
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: "text.secondary",
+                  mb: 4,
+                  letterSpacing: "0.02em",
+                  textAlign: { xs: "center", md: "left" },
+                }}
+              >
+                Common starting points: lead response, quote intake, internal
+                routing, scheduling, and document handoffs.
               </Typography>
 
               <Box
@@ -287,7 +320,7 @@ export default function Home({
                     size="large"
                     text="Schedule a Call"
                     showIcon={false}
-                    aria-label="Schedule a consultation call with our AI automation experts via Calendly"
+                    ariaLabel="Schedule a consultation call with our workflow systems team via Calendly"
                   />
                 </Stack>
                 <Box
@@ -299,9 +332,9 @@ export default function Home({
                   <RequestFormButton
                     fullWidth
                     size="large"
-                    text="See What You Can Automate"
+                    text="See Example Workflows"
                     href="/services"
-                    aria-label="See what you can automate"
+                    ariaLabel="See example workflow systems"
                     sx={{
                       color: "var(--color-text-primary)",
                       borderColor: "var(--color-text-primary)",
@@ -396,11 +429,10 @@ export default function Home({
                       fontSize: "1.125rem",
                       lineHeight: 1.8
                     }}>
-                    Senna Automation builds systems that take work off your
-                    plate and keep your business moving. Instead of juggling
-                    emails, follow-ups, and repetitive tasks, your workflows run
-                    quietly in the background, turning inputs into completed
-                    outcomes.
+                    We build systems that take work off your plate and keep the
+                    day moving. Instead of juggling emails, follow-ups, and
+                    repetitive tasks, the right steps happen quietly in the
+                    background, turning inputs into completed outcomes.
                   </Typography>
 
                   <Typography
@@ -410,7 +442,7 @@ export default function Home({
                       fontSize: "1.125rem",
                       lineHeight: 1.8
                     }}>
-                    We design and build custom automation systems for small and
+                    We design and build custom workflow systems for small and
                     mid-sized businesses, combining modern AI with software that
                     fits the tools you already use. The result is less manual
                     work, fewer gaps, and more time focused on what actually
@@ -428,8 +460,8 @@ export default function Home({
                       py: 1,
                       mt: 2
                     }}>
-                    Based in Grand Rapids, Michigan, Senna Automation helps
-                    businesses <strong>simplify operations</strong>,{" "}
+                    Based in Grand Rapids, Michigan, we help businesses{" "}
+                    <strong>simplify operations</strong>,{" "}
                     <strong>reduce back-and-forth</strong>, and create systems
                     they can rely on.
                   </Typography>
@@ -736,7 +768,7 @@ export default function Home({
                   color: "var(--color-text-inverse)",
                 }}
               >
-                Using homegrown tools or internal systems? We build automation
+                Using homegrown tools or internal systems? We build workflow
                 directly into those as well.
               </Typography>
               <Button
@@ -943,53 +975,64 @@ export default function Home({
               mb: 8,
               opacity: 0.7
             }}>
-            A few common questions about how automation works and where to
+            A few common questions about how these systems work and where to
             start.
           </Typography>
 
           <CascadingStagger spacing={2}>
-            {faqs.map((faq) => (
-              <Accordion
+            {homeFaqEntries.map((faq) => (
+              <Card
                 key={faq.question}
-                disableGutters
-                slotProps={{ transition: { timeout: 140 } }}
                 sx={{
                   bgcolor: "background.paper",
-                  borderColor: "divider",
                   color: "inherit",
-                  "&.Mui-expanded": {
-                    bgcolor: "background.paper",
-                  },
+                  border: "1px solid",
+                  borderColor: "divider",
                 }}
               >
-                <AccordionSummary
-                  expandIcon={
-                    <ExpandMoreIcon sx={{ color: "primary.light" }} />
-                  }
-                >
-                  <Typography variant="h5" sx={{
-                    color: "inherit"
-                  }}>
+                <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+                  <Typography
+                    variant="h5"
+                    sx={{
+                      color: "inherit",
+                      mb: 2,
+                    }}
+                  >
                     {faq.question}
                   </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
                   <Typography
                     component="div"
                     variant="body1"
                     sx={{ color: "text.secondary" }}
                   >
-                    {faq.answer}
+                    {faq.paragraphs.map((paragraph, index) => (
+                      <Box
+                        key={`${faq.question}-paragraph-${index}`}
+                        component="p"
+                        sx={{ m: 0, mt: index === 0 ? 0 : 2 }}
+                      >
+                        {paragraph}
+                      </Box>
+                    ))}
+                    {faq.bulletPoints?.length ? (
+                      <Box component="ul" sx={{ mt: 2, mb: 0, pl: 3 }}>
+                        {faq.bulletPoints.map((point) => (
+                          <Box component="li" key={point}>
+                            {point}
+                          </Box>
+                        ))}
+                      </Box>
+                    ) : null}
                   </Typography>
-                </AccordionDetails>
-              </Accordion>
+                </CardContent>
+              </Card>
             ))}
           </CascadingStagger>
         </Container>
       </Box>
       <LocalSeoClusterSection
         title="Start with the kind of help you need"
-        description="Whether you need a clear AI plan, hands-on automation, or a better way to move work through the business, these pages show how we help Grand Rapids and West Michigan teams."
+        description="Whether you need a clear AI plan, hands-on workflow support, or a better way to move work through the business, these pages show how we help Grand Rapids and West Michigan teams."
         sx={{
           py: { xs: 10, md: 15 },
           bgcolor: "background.paper",

--- a/src/site/pages/search.tsx
+++ b/src/site/pages/search.tsx
@@ -1,0 +1,277 @@
+import Link from "@/compat/next/link";
+import type { RouteMetadata } from "@/utils/metadata";
+import type { SearchResult } from "@/utils/search";
+import { SITE_URL } from "@/utils/site";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+export const metadata: RouteMetadata = {
+  title: "Search | Senna Automation",
+  description:
+    "Search Senna Automation pages, local service content, and blog posts for workflow systems, AI consulting, and operations improvements.",
+  alternates: {
+    canonical: `${SITE_URL}/search`,
+  },
+};
+
+const suggestedSearches = [
+  "lead follow-up",
+  "inventory",
+  "quoting",
+  "Grand Rapids AI consulting",
+  "workflow systems",
+];
+
+const searchActionAttributes = {
+  toolname: "site_search",
+  tooldescription:
+    "Search Senna Automation pages, local service content, and blog posts by keyword.",
+} as const;
+
+export default function SearchPage({
+  query,
+  results,
+}: {
+  query: string;
+  results: SearchResult[];
+}) {
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
+      <Box
+        component="section"
+        sx={{
+          bgcolor: "secondary.main",
+          color: "background.paper",
+          pt: { xs: 16, md: 28 },
+          pb: { xs: 8, md: 10 },
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.03,
+            backgroundImage:
+              'url("https://www.transparenttextures.com/patterns/dark-matter.png")',
+            pointerEvents: "none",
+          }}
+        />
+        <Container maxWidth="lg" sx={{ position: "relative", zIndex: 1 }}>
+          <Stack spacing={3} sx={{ maxWidth: 760 }}>
+            <Typography
+              variant="overline"
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                width: "fit-content",
+                px: 1.75,
+                py: 0.5,
+                border: "1px solid",
+                borderColor: "var(--color-border-medium)",
+                borderRadius: "var(--radius-pill)",
+                bgcolor:
+                  "color-mix(in srgb, var(--color-accent-cyan), transparent 84%)",
+                color: "var(--color-text-secondary)",
+                letterSpacing: "0.12em",
+              }}
+            >
+              Search
+            </Typography>
+            <Typography component="h1" variant="h1" sx={{ color: "inherit" }}>
+              Search pages, guides, and local service content
+            </Typography>
+            <Typography
+              variant="subtitle1"
+              sx={{
+                color: "var(--color-text-on-dark)",
+                maxWidth: 680,
+              }}
+            >
+              Find service pages, location pages, and blog posts about workflow
+              systems, operations handoffs, and AI consulting.
+            </Typography>
+            <Box
+              component="form"
+              action="/search"
+              method="get"
+              role="search"
+              aria-label="Search the Senna Automation website"
+              sx={{
+                display: "flex",
+                gap: 2,
+                alignItems: "flex-start",
+                flexDirection: { xs: "column", sm: "row" },
+                maxWidth: 760,
+              }}
+            >
+              <TextField
+                fullWidth
+                id="site-search-query"
+                name="q"
+                label="Search the site"
+                placeholder="Try: lead follow-up, quoting, inventory, Grand Rapids AI consulting"
+                defaultValue={query}
+                autoComplete="off"
+                helperText="Use keywords from your process, industry, or bottleneck."
+                sx={{
+                  "& .MuiOutlinedInput-root": {
+                    bgcolor: "background.paper",
+                  },
+                  "& .MuiFormHelperText-root": {
+                    color: "var(--color-text-on-dark-body)",
+                  },
+                }}
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                size="large"
+                {...searchActionAttributes}
+                sx={{
+                  minWidth: { sm: 160 },
+                  mt: { sm: 0.5 },
+                }}
+              >
+                Search
+              </Button>
+            </Box>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box component="section" sx={{ py: { xs: 8, md: 10 } }}>
+        <Container maxWidth="lg">
+          <Stack spacing={4}>
+            <Box>
+              <Typography variant="h2" component="h2" sx={{ mb: 1.5 }}>
+                {hasQuery
+                  ? `${results.length} result${results.length === 1 ? "" : "s"} for “${query}”`
+                  : "Start with a common search"}
+              </Typography>
+              <Typography variant="body1" sx={{ color: "text.secondary" }}>
+                {hasQuery
+                  ? "Results include service pages, location pages, and published blog posts."
+                  : "Search by process, business problem, industry, or service area."}
+              </Typography>
+            </Box>
+
+            {!hasQuery ? (
+              <Stack direction="row" spacing={1.25} useFlexGap flexWrap="wrap">
+                {suggestedSearches.map((term) => (
+                  <Chip
+                    key={term}
+                    component="a"
+                    clickable
+                    href={`/search?q=${encodeURIComponent(term)}`}
+                    label={term}
+                    sx={{
+                      color: "text.primary",
+                      borderColor: "divider",
+                    }}
+                    variant="outlined"
+                  />
+                ))}
+              </Stack>
+            ) : null}
+
+            <Stack spacing={2.5}>
+              {results.map((result) => (
+                <Card
+                  key={result.url}
+                  sx={{
+                    border: "1px solid",
+                    borderColor: "divider",
+                    boxShadow: "none",
+                  }}
+                >
+                  <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+                    <Stack spacing={1.5}>
+                      <Chip
+                        label={result.type}
+                        size="small"
+                        sx={{ width: "fit-content" }}
+                        variant="outlined"
+                      />
+                      <Typography variant="h4" component="h3">
+                        <Box
+                          component={Link}
+                          href={result.url.replace(SITE_URL, "") || "/"}
+                          sx={{
+                            color: "inherit",
+                            textDecoration: "none",
+                            "&:hover": { color: "primary.main" },
+                          }}
+                        >
+                          {result.title}
+                        </Box>
+                      </Typography>
+                      <Typography variant="body1" sx={{ color: "text.secondary" }}>
+                        {result.description}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: "text.secondary",
+                          wordBreak: "break-all",
+                        }}
+                      >
+                        {result.url}
+                      </Typography>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              ))}
+
+              {hasQuery && results.length === 0 ? (
+                <Card
+                  sx={{
+                    border: "1px solid",
+                    borderColor: "divider",
+                    boxShadow: "none",
+                  }}
+                >
+                  <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+                    <Stack spacing={2}>
+                      <Typography variant="h4" component="h3">
+                        No direct matches yet
+                      </Typography>
+                      <Typography variant="body1" sx={{ color: "text.secondary" }}>
+                        Try a broader process term like “lead follow-up,”
+                        “quoting,” “inventory,” or “Grand Rapids AI consulting.”
+                      </Typography>
+                      <Stack direction="row" spacing={1.25} useFlexGap flexWrap="wrap">
+                        {suggestedSearches.map((term) => (
+                          <Chip
+                            key={term}
+                            component="a"
+                            clickable
+                            href={`/search?q=${encodeURIComponent(term)}`}
+                            label={term}
+                            variant="outlined"
+                          />
+                        ))}
+                      </Stack>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              ) : null}
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+    </Box>
+  );
+}

--- a/src/utils/ai-discovery.ts
+++ b/src/utils/ai-discovery.ts
@@ -1,0 +1,96 @@
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/utils/site";
+
+export type HomeFaqEntry = {
+  question: string;
+  paragraphs: string[];
+  bulletPoints?: string[];
+};
+
+export const homeFaqEntries: HomeFaqEntry[] = [
+  {
+    question: "How is this different from other workflow tools?",
+    paragraphs: [
+      "There are already powerful platforms out there, but most are built for large teams and require time to learn and maintain.",
+      "Senna Automation designs and ships around your business, so you get a working process instead of another tool your team has to manage.",
+    ],
+  },
+  {
+    question: "Do I need to be technical to use this?",
+    paragraphs: [
+      "No.",
+      "Everything is set up to match how your business already works, so your team interacts with simple inputs like emails, forms, or messages while the workflow runs quietly in the background.",
+    ],
+  },
+  {
+    question: "What kinds of work can the system handle?",
+    paragraphs: [
+      "Anything that follows a pattern and needs consistent handoff.",
+      "Most businesses are already doing this work manually before it gets translated into a repeatable system.",
+    ],
+    bulletPoints: [
+      "Incoming leads getting organized and qualified",
+      "Follow-ups happening without reminders",
+      "Scheduling handled without back-and-forth",
+      "Invoices or documents created from conversations",
+      "Tasks moving between people without manual coordination",
+    ],
+  },
+  {
+    question: "How do I get started?",
+    paragraphs: [
+      "We start by looking at where work is getting stuck or repeated.",
+      "From there, we build one system that takes that off your plate, then expand into other areas once the first workflow is running cleanly.",
+    ],
+  },
+];
+
+export function formatAiFaqAnswer(entry: HomeFaqEntry) {
+  const segments = [...entry.paragraphs];
+
+  if (entry.bulletPoints?.length) {
+    segments.push(`That usually includes: ${entry.bulletPoints.join("; ")}.`);
+  }
+
+  return segments.join(" ");
+}
+
+export const aiServiceProfile = {
+  name: SITE_NAME,
+  description: SITE_DESCRIPTION,
+  url: SITE_URL,
+  service_area: [
+    "Grand Rapids, Michigan",
+    "West Michigan",
+    "United States",
+  ],
+  capabilities: [
+    {
+      name: "Workflow design",
+      description:
+        "Move repetitive internal handoffs, approvals, routing, and back-office tasks across the tools your team already uses.",
+      url: `${SITE_URL}/services`,
+    },
+    {
+      name: "Lead capture and qualification",
+      description:
+        "Capture inquiries, summarize context, score fit, and route leads automatically so no opportunity waits on manual follow-up.",
+      url: `${SITE_URL}/services`,
+    },
+    {
+      name: "Sales follow-up systems",
+      description:
+        "Trigger reminders, email and SMS sequences, and CRM updates that keep pipelines moving without manual chasing.",
+      url: `${SITE_URL}/services`,
+    },
+    {
+      name: "Custom AI assistants and internal tools",
+      description:
+        "Build lightweight assistants, dashboards, and workflow tools that help teams answer questions and complete repeatable work faster.",
+      url: `${SITE_URL}/services`,
+    },
+  ],
+  contact: {
+    url: `${SITE_URL}/contact`,
+    telephone: "+1-616-287-3360",
+  },
+};

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -53,23 +53,23 @@ export interface RouteMetadata {
 
 export const defaultMetadata: RouteMetadata = {
   title:
-    "Senna Automation | AI Workflow Automation & Custom Software Development Grand Rapids, MI",
+    "Senna Automation | AI Workflow Systems & Custom Software Grand Rapids, MI",
   description:
-    "Transform your business with AI workflow automation, custom software development, and modern web solutions. Expert AI automation consulting serving Grand Rapids, Michigan and beyond. Get chatbot development, process automation, and enterprise AI solutions that drive real ROI.",
+    "Senna Automation designs AI workflow systems, custom software, and practical operations tools for Grand Rapids businesses and teams beyond West Michigan.",
   keywords: [
     "Grand Rapids web development",
     "Grand Rapids web design",
     "Michigan web development",
-    "AI workflow automation",
-    "artificial intelligence automation",
-    "business automation software",
-    "workflow automation consulting",
+    "AI workflow systems",
+    "artificial intelligence consulting",
+    "business process software",
+    "workflow consulting",
     "custom software development",
     "custom applications",
     "bespoke software solutions",
     "web development Grand Rapids MI",
     "AI tools for business",
-    "automation consulting",
+    "operations consulting",
     "software development Michigan",
     "chatbot development",
     "business AI integration",
@@ -81,8 +81,8 @@ export const defaultMetadata: RouteMetadata = {
     "responsive web design",
     "high-performance websites",
     "SEO-optimized websites",
-    "process automation consulting",
-    "AI automation Grand Rapids",
+    "process improvement consulting",
+    "AI systems Grand Rapids",
     "Michigan AI solutions",
   ],
   alternates: {
@@ -97,18 +97,18 @@ export const defaultMetadata: RouteMetadata = {
     locale: "en_US",
     url: SITE_URL,
     title:
-      "Senna Automation | AI Workflow Automation & Custom Software Development",
+      "Senna Automation | AI Workflow Systems & Custom Software Development",
     description:
-      "Transform your business with AI workflow automation, custom software development, and modern web solutions. Expert AI automation consulting serving Grand Rapids, Michigan.",
+      "AI workflow systems, custom software, and practical operations tools for Grand Rapids businesses and teams beyond West Michigan.",
     siteName: SITE_NAME,
     images: [`${SITE_URL}/opengraph-image`],
   },
   twitter: {
     card: "summary_large_image",
     title:
-      "Senna Automation | AI Workflow Automation & Custom Software Development",
+      "Senna Automation | AI Workflow Systems & Custom Software Development",
     description:
-      "Transform your business with AI workflow automation, custom software development, and modern web solutions. Expert AI automation consulting serving Grand Rapids, Michigan.",
+      "AI workflow systems, custom software, and practical operations tools for Grand Rapids businesses and teams beyond West Michigan.",
     images: [`${SITE_URL}/opengraph-image`],
   },
 };

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,208 @@
+import { localSeoPages } from "@/components/localSeo/localSeoPages";
+import { getAllBlogPosts } from "@/utils/blog";
+import { SITE_URL } from "@/utils/site";
+
+export type SearchDocumentType = "Page" | "Location Page" | "Blog Post";
+
+export type SearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  type: SearchDocumentType;
+  score: number;
+};
+
+type SearchDocument = {
+  title: string;
+  url: string;
+  description: string;
+  type: SearchDocumentType;
+  content: string;
+};
+
+const marketingPages: SearchDocument[] = [
+  {
+    title: "Home",
+    url: `${SITE_URL}/`,
+    description:
+      "Overview of Senna Automation and its AI workflow, operations, and custom software services.",
+    type: "Page",
+    content:
+      "AI workflow systems for lead follow-up, routing, scheduling, internal operations, business process improvement, and custom software in Grand Rapids and beyond.",
+  },
+  {
+    title: "About",
+    url: `${SITE_URL}/about`,
+    description:
+      "Background on Senna Automation, its consulting approach, and software experience.",
+    type: "Page",
+    content:
+      "Grand Rapids consulting agency helping businesses remove repetitive work, improve handoffs, and run smoother systems.",
+  },
+  {
+    title: "Services",
+    url: `${SITE_URL}/services`,
+    description:
+      "Workflow systems, lead generation, sales follow-up, assistants, and internal tools.",
+    type: "Page",
+    content:
+      "Workflow design, lead capture, CRM routing, sales follow-up, internal assistants, dashboards, and business operations support.",
+  },
+  {
+    title: "Solutions",
+    url: `${SITE_URL}/solutions`,
+    description:
+      "Common operational bottlenecks solved with workflow design, data routing, and AI-enabled systems.",
+    type: "Page",
+    content:
+      "Administrative work, qualified leads, structured data, custom logic, notifications, approvals, and internal workflows.",
+  },
+  {
+    title: "Pricing",
+    url: `${SITE_URL}/pricing`,
+    description:
+      "Starting prices, implementation timelines, and project planning for custom workflow systems.",
+    type: "Page",
+    content:
+      "Pricing starts at 500 dollars, typical implementation in four to six weeks, fixed-scope planning, and assessments.",
+  },
+  {
+    title: "Contact",
+    url: `${SITE_URL}/contact`,
+    description:
+      "Request a free assessment or contact Senna Automation directly.",
+    type: "Page",
+    content:
+      "Free assessment, contact form, schedule a call, Grand Rapids consulting, discuss workflow bottlenecks and operations.",
+  },
+  {
+    title: "Blog",
+    url: `${SITE_URL}/blog`,
+    description:
+      "Practical articles and case studies on workflow systems, operations handoffs, and business AI.",
+    type: "Page",
+    content:
+      "Automation case studies, practical guides, lead qualification, quoting, inventory coordination, and service scheduling.",
+  },
+];
+
+function createLocationDocuments(): SearchDocument[] {
+  return Object.values(localSeoPages).map((page) => ({
+    title: page.serviceName,
+    url: `${SITE_URL}/${page.slug}`,
+    description: page.description,
+    type: "Location Page",
+    content: [
+      page.serviceType,
+      page.lead,
+      page.introBody,
+      page.assessmentBody,
+      page.primaryKeyword,
+      ...page.secondaryKeywords,
+      ...page.useCases.map((useCase) => `${useCase.title} ${useCase.description}`),
+      ...page.industries.map((industry) => `${industry.name} ${industry.description}`),
+      ...page.process.map((step) => `${step.title} ${step.description}`),
+      ...page.faqs.map((faq) => `${faq.question} ${faq.answer}`),
+    ].join(" "),
+  }));
+}
+
+function createBlogDocuments(): SearchDocument[] {
+  return getAllBlogPosts().map((post) => ({
+    title: post.title,
+    url: `${SITE_URL}/blog/${post.slug}`,
+    description: post.excerpt,
+    type: "Blog Post",
+    content: [
+      post.title,
+      post.subtitle ?? "",
+      post.heroTitle ?? "",
+      post.heroSubtitle ?? "",
+      post.category,
+      post.excerpt,
+      post.metadata.client,
+      post.metadata.company,
+      post.metadata.role,
+      post.metadata.tools,
+    ].join(" "),
+  }));
+}
+
+function normalize(value: string) {
+  return value.toLowerCase().replace(/[^\p{L}\p{N}\s/-]+/gu, " ");
+}
+
+function countOccurrences(haystack: string, needle: string) {
+  if (!needle) return 0;
+
+  let count = 0;
+  let index = haystack.indexOf(needle);
+
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+
+  return count;
+}
+
+function scoreDocument(document: SearchDocument, query: string, terms: string[]) {
+  const title = normalize(document.title);
+  const description = normalize(document.description);
+  const content = normalize(document.content);
+  const url = normalize(document.url);
+  const exactQuery = normalize(query).trim();
+
+  let score = 0;
+
+  if (exactQuery) {
+    if (title.includes(exactQuery)) score += 18;
+    if (description.includes(exactQuery)) score += 12;
+    if (content.includes(exactQuery)) score += 7;
+  }
+
+  for (const term of terms) {
+    score += countOccurrences(title, term) * 10;
+    score += countOccurrences(description, term) * 5;
+    score += countOccurrences(content, term) * 2;
+    score += countOccurrences(url, term);
+  }
+
+  return score;
+}
+
+export function getSearchIndex() {
+  return [
+    ...marketingPages,
+    ...createLocationDocuments(),
+    ...createBlogDocuments(),
+  ];
+}
+
+export function searchSiteContent(query: string) {
+  const normalizedQuery = normalize(query).trim();
+  const terms = normalizedQuery.split(/\s+/).filter(Boolean);
+  const documents = getSearchIndex();
+
+  if (!terms.length) {
+    return documents.slice(0, 8).map((document) => ({
+      title: document.title,
+      url: document.url,
+      description: document.description,
+      type: document.type,
+      score: 0,
+    }));
+  }
+
+  return documents
+    .map((document) => ({
+      title: document.title,
+      url: document.url,
+      description: document.description,
+      type: document.type,
+      score: scoreDocument(document, query, terms),
+    }))
+    .filter((document) => document.score > 0)
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, 20);
+}

--- a/src/utils/site-jsonld.ts
+++ b/src/utils/site-jsonld.ts
@@ -1,12 +1,11 @@
-import { LOGO_URL, SITE_NAME, SITE_URL } from "@/utils/site";
+import { LOGO_URL, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/utils/site";
 
 export const organizationJsonLd = {
   "@context": "https://schema.org",
   "@type": "Organization",
   "@id": `${SITE_URL}/#organization`,
   name: SITE_NAME,
-  description:
-    "AI workflow automation and custom software development company serving Grand Rapids, Michigan and businesses worldwide. Specializing in business AI integration, chatbot development, process automation consulting, and enterprise AI solutions.",
+  description: SITE_DESCRIPTION,
   url: SITE_URL,
   logo: LOGO_URL,
   contactPoint: {
@@ -25,6 +24,7 @@ export const organizationJsonLd = {
   sameAs: [
     "https://linkedin.com/company/senna-automation",
     "https://instagram.com/sennaautomation",
+    "https://www.facebook.com/senna.automation",
     "https://www.bbb.org/us/mi/grand-rapids/profile/artificial-intelligence/senna-automation-0372-90070205",
     "https://web.grandrapids.org/AI-(Artificial-Intelligence)/Senna-Automation-11264",
   ],
@@ -34,23 +34,20 @@ export const organizationJsonLd = {
     url: "https://www.justinkahrs.com",
   },
   knowsAbout: [
-    "AI workflow automation",
     "AI consulting",
-    "AI automation",
-    "business automation consulting",
-    "workflow automation consulting",
-    "business process automation",
+    "workflow systems",
+    "business operations consulting",
+    "process design",
+    "business process design",
     "custom software development",
     "custom AI solutions",
     "web development",
-    "chatbot development",
-    "lead follow-up automation",
-    "document processing automation",
+    "lead follow-up systems",
+    "document processing",
     "internal AI assistants",
-    "process automation",
-    "West Michigan business automation",
+    "West Michigan operations consulting",
     "digital transformation",
-    "enterprise AI solutions",
+    "enterprise AI solutions"
   ],
 };
 
@@ -59,8 +56,7 @@ export const localBusinessJsonLd = {
   "@type": "ProfessionalService",
   "@id": `${SITE_URL}/#localbusiness`,
   name: SITE_NAME,
-  description:
-    "AI workflow automation and custom software development company in Grand Rapids, Michigan. We help businesses automate workflows, integrate AI solutions, and build custom applications.",
+  description: SITE_DESCRIPTION,
   url: SITE_URL,
   telephone: "+1-616-287-3360",
   address: {
@@ -88,6 +84,7 @@ export const localBusinessJsonLd = {
   sameAs: [
     "https://linkedin.com/company/senna-automation",
     "https://instagram.com/sennaautomation",
+    "https://www.facebook.com/senna.automation",
     "https://www.bbb.org/us/mi/grand-rapids/profile/artificial-intelligence/senna-automation-0372-90070205",
     "https://web.grandrapids.org/AI-(Artificial-Intelligence)/Senna-Automation-11264",
   ],
@@ -98,9 +95,18 @@ export const websiteJsonLd = {
   "@type": "WebSite",
   "@id": `${SITE_URL}/#website`,
   name: SITE_NAME,
+  description: SITE_DESCRIPTION,
   url: SITE_URL,
   inLanguage: "en-US",
   publisher: {
     "@id": `${SITE_URL}/#organization`,
+  },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
   },
 };

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -5,6 +5,7 @@ const readProcessEnv = (key: string) =>
 
 export const SITE_NAME = siteConfig.siteName;
 export const SITE_URL = siteConfig.siteUrl.replace(/\/$/, "");
+export const SITE_DESCRIPTION = siteConfig.siteDescription;
 export const SITE_HOST = new URL(SITE_URL).host;
 
 export const RSS_FEED_URL = `${SITE_URL}/rss.xml`;

--- a/vendor/astro-geoready/index.mjs
+++ b/vendor/astro-geoready/index.mjs
@@ -1,0 +1,169 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function humanize(segment) {
+  if (!segment) return "";
+
+  return segment
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function groupPages(pages, maxPerSection) {
+  const sections = new Map();
+
+  for (const { pathname } of pages) {
+    const clean = pathname.replace(/^\/+|\/+$/g, "");
+    if (clean.startsWith("404") || clean.startsWith("500")) continue;
+
+    const segments = clean.split("/").filter(Boolean);
+    const section = segments.length > 1 ? humanize(segments[0]) : "Pages";
+    const title = humanize(segments[segments.length - 1] || "Home") || "Home";
+
+    if (!sections.has(section)) sections.set(section, []);
+
+    const entries = sections.get(section);
+    if (entries.length < maxPerSection) {
+      entries.push({ title, pathname: clean });
+    }
+  }
+
+  return [...sections.entries()].sort(([a], [b]) =>
+    a === "Pages" ? -1 : b === "Pages" ? 1 : a.localeCompare(b),
+  );
+}
+
+function buildLlmsTxt({ siteName, description, siteUrl, pages, maxPerSection }) {
+  const lines = [`# ${siteName}`, ""];
+
+  if (description) {
+    lines.push(`> ${description}`, "");
+  }
+
+  for (const [section, entries] of groupPages(pages, maxPerSection)) {
+    lines.push(`## ${section}`, "");
+
+    for (const { title, pathname } of entries) {
+      const url = pathname ? `${siteUrl}/${pathname}/` : `${siteUrl}/`;
+      lines.push(`- [${title}](${url})`);
+    }
+
+    lines.push("");
+  }
+
+  lines.push(
+    "Generated at build time by astro-geoready. Audit this site: https://geoready.dev",
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+function buildAiTxt({ siteName, siteUrl }) {
+  return [
+    `# ai.txt - AI crawler guidance for ${siteName}`,
+    "# Spec: https://site.spawning.ai/spawning-ai-txt",
+    "",
+    "User-Agent: *",
+    "Allow: /",
+    "",
+    `Sitemap: ${siteUrl}/sitemap.xml`,
+    `LLMs: ${siteUrl}/llms.txt`,
+    "",
+  ].join("\n");
+}
+
+function buildSummaryJson({ siteName, description, siteUrl, pages }) {
+  return (
+    JSON.stringify(
+      {
+        name: siteName,
+        description: description || undefined,
+        url: siteUrl,
+        pages_count: pages.length,
+        llms_txt: `${siteUrl}/llms.txt`,
+        generated_by: "astro-geoready",
+        generated_at: new Date().toISOString(),
+      },
+      null,
+      2,
+    ) + "\n"
+  );
+}
+
+export default function geoReady(options = {}) {
+  const {
+    siteName,
+    description = "",
+    llmsTxt = true,
+    aiDiscovery = true,
+    overwrite = false,
+    maxPerSection = 20,
+  } = options;
+
+  let siteUrl = "";
+
+  async function emit(dirPath, relative, content, logger) {
+    const target = path.join(dirPath, relative);
+
+    if (!overwrite && existsSync(target)) {
+      logger.info(
+        `${relative} already exists - skipped (set overwrite: true to regenerate)`,
+      );
+      return;
+    }
+
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, content, "utf-8");
+    logger.info(`generated ${relative}`);
+  }
+
+  return {
+    name: "astro-geoready",
+    hooks: {
+      "astro:config:done": ({ config }) => {
+        siteUrl = (config.site || "").replace(/\/+$/, "");
+      },
+      "astro:build:done": async ({ pages, dir, logger }) => {
+        if (!siteUrl) {
+          logger.warn(
+            "`site` is not set in astro.config - skipping (absolute URLs are required)",
+          );
+          return;
+        }
+
+        const dirPath = fileURLToPath(dir);
+        const name = siteName || new URL(siteUrl).hostname;
+        const context = {
+          siteName: name,
+          description,
+          siteUrl,
+          pages,
+          maxPerSection,
+        };
+
+        if (llmsTxt) {
+          await emit(dirPath, "llms.txt", buildLlmsTxt(context), logger);
+        }
+
+        if (aiDiscovery) {
+          await emit(
+            dirPath,
+            path.join(".well-known", "ai.txt"),
+            buildAiTxt(context),
+            logger,
+          );
+          await emit(
+            dirPath,
+            path.join("ai", "summary.json"),
+            buildSummaryJson(context),
+            logger,
+          );
+        }
+      },
+    },
+  };
+}

--- a/vendor/astro-geoready/package.json
+++ b/vendor/astro-geoready/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "astro-geoready",
+  "version": "0.1.0",
+  "description": "Make your Astro site GEO-ready at build time: generates llms.txt and AI discovery files (ai.txt, ai/summary.json) from your built routes.",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "files": [
+    "index.mjs"
+  ],
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "geo",
+    "llms.txt",
+    "ai-visibility"
+  ],
+  "author": "Auriti Labs",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Auriti-Labs/geo-optimizer-skill.git",
+    "directory": "integrations/astro-geoready"
+  },
+  "peerDependencies": {
+    "astro": ">=4.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Astro GEO discovery support, search, and companion AI discovery files
- improve homepage copy and metadata to reduce repeated "automation" phrasing while keeping the brand voice intact
- tighten schema, llms, form semantics, captions, and agent-oriented annotations picked up by the GEO audit

## Why
- the site was missing several GEO discovery surfaces and structured signals
- the homepage copy and inherited metadata were overusing the same keyword, which was dragging the audit score and making the language flatter than it needed to be

## Impact
- publishes a real `/search` surface and wires `SearchAction` to it
- improves homepage and shared copy quality without changing the overall visual direction of the site
- raises the local GEO audit result and removes the keyword stuffing finding from the homepage

## Validation
- `npm run lint`
- `npm run build`
- `npm run token-audit`
